### PR TITLE
Anglicizing <language> for HGV trans

### DIFF
--- a/data/templates/hgv_trans_identifier.xml.erb
+++ b/data/templates/hgv_trans_identifier.xml.erb
@@ -23,14 +23,14 @@
     </fileDesc>
     <profileDesc>
       <langUsage>
-        <language ident="fr">Französisch</language>
-        <language ident="en">Englisch</language>
-        <language ident="de">Deutsch</language>
-        <language ident="it">Italienisch</language>
-        <language ident="es">Spanisch</language>
-        <language ident="la">Latein</language>
-        <language ident="el">Griechisch</language>
-        <language ident="ar">Arabisch</language>
+        <language ident="fr">French</language>
+        <language ident="en">English</language>
+        <language ident="de">German</language>
+        <language ident="it">Italian</language>
+        <language ident="es">Spanish</language>
+        <language ident="la">Latin</language>
+        <language ident="el">Modern Greek</language>
+        <language ident="ar">Arabic</language>
       </langUsage>
     </profileDesc>
     <revisionDesc>


### PR DESCRIPTION
As per discussion with Cowey re: the English terminology in PN and xslt for translations, this commit updates the HGV translation template. Overwrite of existing files has been proposed in [a recent pull request](https://github.com/papyri/idp.data/pull/320) for idp.data.